### PR TITLE
fix: Add caret to avoid prompting on buffer load

### DIFF
--- a/ftplugin/cypher.vim
+++ b/ftplugin/cypher.vim
@@ -11,6 +11,6 @@ if exists('b:did_ftplugin')
 endif
 
 let b:did_ftplugin = 1
-let b:undo_ftplugin = 'setlocal commentstring'
+let b:undo_ftplugin = 'setlocal commentstring<'
 
 setlocal commentstring=//%s


### PR DESCRIPTION
This fixes the issue where a prompt requires any key stroke when switching to a buffer using the syntax plugin.

Based on the answer to [this Stack Exchange answer](https://vi.stackexchange.com/a/44840/43561) from `@maxim-kim`